### PR TITLE
Adding Atlas web bulk application secrets,configmaps and service:

### DIFF
--- a/charts/gxa/Chart.yaml
+++ b/charts/gxa/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gxa/README.md
+++ b/charts/gxa/README.md
@@ -1,0 +1,15 @@
+# GXA chart
+
+Deployment
+
+```bash
+helm upgrade \
+  --reuse-values gxa-test \
+  -f values.yaml \
+  --set tomcat.deployerPassword=tomcat  \
+  --set secrets.solr.password=.. \
+  --set secrets.solr.username=.. \
+  --set secrets.jdbc.password=.. \
+  --set secrets.jdbc.username=.. \
+  .
+```

--- a/charts/gxa/templates/configmap.yaml
+++ b/charts/gxa/templates/configmap.yaml
@@ -21,13 +21,23 @@ data:
     </Server> 
 
   configuration.properties: |
-    data.files.location = /srv/gxa/data
-    experiment.files.location = /srv/gxa/data/gxa
-    experiment.design.location= /srv/gxa/data/gxa/expdesign/
+    data.files.location = {{ .Values.data.files.location }}
+    experiment.files.location = {{ .Values.experiment.files.location }}
+    experiment.design.location = {{ .Values.experiment.design.location }}
 
     #build.number = 1
     #build.branch = main
     #build.commitId = foobar
     #build.tomcatHostname = foobar
+  
+  jdbc.properties: |
+    jdbc.url = {{ .Values.jdbc.url }}
+    jdbc.username = ${JDBC_USERNAME}
+    jdbc.password = ${JDBC_PASSWORD}
+    jdbc.pool = gxa
 
-
+  solr.properties: |
+    zk.hosts = gxa-solrcloud-zookeeper-0:2181,gxa-solrcloud-zookeeper-1:2181,gxa-solrcloud-zookeeper-2:2181
+    solr.hosts = http://gxa-solrcloud-0:8983/solr,http://gxa-solrcloud-1:8983/solr
+    solr.user = ${JDBC_PASSWORD}
+    solr.pass = ${SOLR_PASSWORD}

--- a/charts/gxa/templates/deployment.yaml
+++ b/charts/gxa/templates/deployment.yaml
@@ -57,19 +57,22 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: gxa-codon-volume
-              mountPath: /srv/gxa/data/gxa_codon
+              mountPath: "{{ .Values.data.files.location }}/gxa_codon"
               readOnly: true
             - name: experiments-snapshot 
-              mountPath: /srv/gxa/data/gxa/magetab
+              mountPath: "{{ .Values.experiment.files.location }}/magetab"
               # subPath: magetab
               readOnly: true
             - name: gxa-volume
-              mountPath: /srv/gxa/data/gxa/release-metadata.json
+              mountPath: "{{ .Values.experiment.files.location }}/release-metadata.json"
               subPath: release-metadata.json
               readOnly: true
             - name: gxa-codon-volume
-              mountPath: /srv/gxa/data/gxa/species-properties.json
-              subPath: species-properties.json        
+              mountPath: "{{ .Values.experiment.files.location }}/species-properties.json"
+              subPath: species-properties.json
+            - name: gxa-codon-volume
+              mountPath: "{{ .Values.data.files.location }}/bioentity_properties"
+              subPath: web_app_bioentity_properties
             # - name: {{ include "gxa.fullname" . }}-config
               # mountPath: /usr/local/tomcat/conf/server.xml
               # subPath: server.xml
@@ -82,6 +85,39 @@ spec:
               mountPath: /usr/local/tomcat/work
             - name: tomcat-webapps
               mountPath: /usr/local/tomcat/webapps
+              readOnly: false
+            - name: tomcat-config
+              mountPath: /webapp-properties/solr.properties
+              subPath: solr.properties
+            - name: tomcat-config
+              mountPath: /webapp-properties/configuration.properties
+              subPath: configuration.properties
+            - name: tomcat-config
+              mountPath: /webapp-properties/jdbc.properties
+              subPath: jdbc.properties
+          env:
+            - name: TOMCAT_PASSWORD
+              value: {{ .Values.tomcat.deployerPassword }}
+            - name: JDBC_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gxa.fullname" . }}-jdbc-creds
+                  key: username
+            - name: JDBC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gxa.fullname" . }}-jdbc-creds
+                  key: password
+            - name: SOLR_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gxa.fullname" . }}-solr-creds
+                  key: username
+            - name: SOLR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gxa.fullname" . }}-solr-creds
+                  key: password
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -113,6 +149,13 @@ spec:
             items:
               - key: server.xml
                 path: server.xml
+               ## Can we mount the whole configmap and use the subpath on the volumeMount? 
+              - key: jdbc.properties
+                path: jdbc.properties
+              - key: solr.properties
+                path: solr.properties
+              - key: configuration.properties
+                path: configuration.properties
         - name: tomcat-users
           secret:
             secretName: {{ include "gxa.fullname" . }}-secrets
@@ -124,7 +167,8 @@ spec:
         - name: tomcat-work
           emptyDir: {}
         - name: tomcat-webapps
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: "{{ include "gxa.fullname" . }}-webapps-volume"
       initContainers:
         - name: gxa-init-codon-snapshot
           image: busybox
@@ -134,7 +178,7 @@ spec:
             - name: gxa-codon-volume
               mountPath: /srv/gxa/data/gxa_codon
             - name: experiments-snapshot
-              mountPath: /experiments_snapshot                 
+              mountPath: /experiments_snapshot 
 
         - name: gxa-init-tomcat-manager
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -142,4 +186,4 @@ spec:
           command: [ "sh", "-c", "cp -r /usr/local/tomcat/webapps.dist/manager /usr/local/tomcat/webapps/" ]
           volumeMounts:
             - name: tomcat-webapps
-              mountPath: /usr/local/tomcat/webapps                 
+              mountPath: /usr/local/tomcat/webapps

--- a/charts/gxa/templates/secret.yaml
+++ b/charts/gxa/templates/secret.yaml
@@ -8,8 +8,31 @@ type: Opaque
 stringData:
   tomcat-users.xml: |
     <tomcat-users>
+      <role rolename="manager-script"/>
       <role rolename="manager-gui"/>
-      <user username="deployer" password="{{ .Values.tomcat.deployerPassword }}" roles="manager-gui"/>
+      <user username="deployer" password="{{ .Values.tomcat.deployerPassword }}" roles="manager-gui,manager-script"/>
     </tomcat-users> 
+---
+apiVersion: v1
+stringData:
+  password: {{ .Values.secrets.solr.password }}
+  username: {{ .Values.secrets.solr.username }}
+kind: Secret
+metadata:
+  name: {{ include "gxa.fullname" . }}-solr-creds
+  labels:
+    {{- include "gxa.labels" . | nindent 4 }}
+type: Opaque
+---
+apiVersion: v1
+stringData:
+  password: {{ .Values.secrets.jdbc.password }}
+  username: {{ .Values.secrets.jdbc.username }}
+kind: Secret
+metadata:
+  name: {{ include "gxa.fullname" . }}-jdbc-creds
+  labels:
+    {{- include "gxa.labels" . | nindent 4 }}
+type: Opaque
 
 

--- a/charts/gxa/templates/service.yaml
+++ b/charts/gxa/templates/service.yaml
@@ -11,5 +11,6 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      nodePort: {{ .Values.service.nodePort}}
   selector:
     {{- include "gxa.selectorLabels" . | nindent 4 }}

--- a/charts/gxa/templates/volume.yaml
+++ b/charts/gxa/templates/volume.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ include "gxa.fullname" . }}-webapps-volume"
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.tomcat.webapps.volume.size }}
+  storageClassName: {{ .Values.tomcat.webapps.volume.storageClassName }}

--- a/charts/gxa/values.yaml
+++ b/charts/gxa/values.yaml
@@ -5,10 +5,10 @@
 replicaCount: 1
 
 image:
-  repository: tomcat
+  repository: dockerhub.ebi.ac.uk/davidg/atlas-web-bulk
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "8-jdk11"
+  tag: "c043a5c5" 
 
 imagePullSecrets: []
 nameOverride: ""
@@ -36,10 +36,12 @@ securityContext:
   # runAsNonRoot: true
   runAsUser: 2921
   runAsGroup: 1146
+  # fsGroup: 1146
 
 service:
-  type: ClusterIP
+  type: NodePort
   port: 80
+  nodePort: 32000
 
 ingress:
   enabled: false
@@ -71,8 +73,8 @@ resources: {}
 
 autoscaling:
   enabled: false
-  minReplicas: 1
-  maxReplicas: 100
+  minReplicas: 2
+  maxReplicas: 3
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
@@ -84,7 +86,31 @@ affinity: {}
 
 tomcat:
   httpPort: 8080
-  # deployerPassword: set-in-commandline
+  webapps:
+    volume:
+      size: 10Gi 
+      storageClassName: standard-nfs-production
+  deployerPassword:
 nfs:
   server: hh-isi-srv-vlan1496.ebi.ac.uk
   snapshotComponent: gxa_codon_2025-07-14_14:10
+
+secrets:
+  jdbc:
+    username:
+    password:
+  solr:
+    username:
+    password:
+
+data:
+  files:
+    location: /srv/gxa/data
+experiment:
+  files:
+    location: /srv/gxa/data/gxa
+  design:
+    location: /srv/gxa/data/gxa/expdesign/
+
+jdbc:
+  url: jdbc:postgresql://pgsql-dlvm-078.ebi.ac.uk:5432/gxpatlastst


### PR DESCRIPTION
- Using a public temporary custom tomcat image with the Atlas NFS virtual user. Once the atlas-web-bulk repo change is merged, the private container image should be used and a secret to authenticate the cluster against the EBI Gitlab server must be added
- Mounting the files/volumes the application needs to start up: bioentity_properties
- Creating confimap keys for the solr and jdbc credentials, and Mounting them as volumes in the pods. The username and password are treated as secrets and are interpolated from env variables by using the expression ${JDBC_USERNAME} in the properties file.
- Creating the SOLR and JDBC credentials as secrets and injecting them as env variables to the pods
- Creating a NodePort service to expose the application in the fixed port 32000.
- attaching the manager-script role to the deployer user