### PR TITLE
[GXA-423] Populate scxa-analytics collection for SCXA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,9 @@ HELM_SET_ARGS += --set jdbc.password="$(subst ",,$(JDBC_PASSWORD))"
 HELM_SET_ARGS += --set bioentities-collection.jdbc.password="$(subst ",,$(JDBC_PASSWORD))"
 endif
 ifdef SOLR_PASSWORD
-$(info Setting solr.password from SOLR_PASSWORD environment variable)
+$(info Setting solr.password and bioentities-collection.solr.password from SOLR_PASSWORD environment variable)
 HELM_SET_ARGS += --set solr.password="$(subst ",,$(SOLR_PASSWORD))"
+HELM_SET_ARGS += --set bioentities-collection.solr.password="$(subst ",,$(SOLR_PASSWORD))"
 endif
 ifdef TOMCAT_DEPLOYER_PASSWORD
 $(info Setting tomcat.deployerPassword from TOMCAT_DEPLOYER_PASSWORD environment variable)

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,9 @@ WAR_FILE_DIR ?= charts/$(RELEASE)/war
 # Set helm --set arguments based on environment variables
 HELM_SET_ARGS = --set appVersion=$(APP_VERSION)
 ifdef JDBC_PASSWORD
-$(info Setting jdbc.password from JDBC_PASSWORD environment variable)
+$(info Setting jdbc.password and bioentities-collection.jdbc.password from JDBC_PASSWORD environment variable)
 HELM_SET_ARGS += --set jdbc.password="$(subst ",,$(JDBC_PASSWORD))"
+HELM_SET_ARGS += --set bioentities-collection.jdbc.password="$(subst ",,$(JDBC_PASSWORD))"
 endif
 ifdef SOLR_PASSWORD
 $(info Setting solr.password from SOLR_PASSWORD environment variable)

--- a/charts/bioentities-collection/templates/_helpers.tpl
+++ b/charts/bioentities-collection/templates/_helpers.tpl
@@ -149,17 +149,14 @@ Root directory for data mounts
 Gradle CLI arguments for running the CLI application
 */}}
 {{- define "app.gradleCliArgs" -}}
-    {{ include "app.jvmProxyArgs" . }} \
-    {{- include "app.loggingArgs" . }}
+{{ include "app.jvmProxyArgs" . }}
 {{- end }}
 
 {{- define "app.loggingArgs" -}}
-    {{- if eq .Values.loggingLevel "DEBUG" }}
-        -Dlogging.level.root=DEBUG \
-        -Dlogging.level.uk.ac.ebi.atlas=DEBUG \
-        -Dlogging.level.org.springframework=DEBUG
-    {{- else if eq .Values.loggingLevel "INFO" }}
-    {{- end }}
+{{- if eq .Values.loggingLevel "DEBUG" }}
+-Dlogging.level.root=DEBUG -Dlogging.level.uk.ac.ebi.atlas=DEBUG -Dlogging.level.org.springframework=DEBUG
+{{- else if eq .Values.loggingLevel "INFO" }}
+{{- end }}
 {{- end }}
 
 {{- define "app.jvmProxyArgs" -}}
@@ -169,11 +166,7 @@ Notes:
 1. the last system property arg is not followed by a backslash
 2. fpr the non proxy hosts, we use substitution
 */ -}}
--Dhttp.proxyHost=${PROXY_HOST} \
--Dhttp.proxyPort=${PROXY_PORT} \
--Dhttps.proxyHost=${PROXY_HOST} \
--Dhttps.proxyPort=${PROXY_PORT} \
--Dhttp.nonProxyHosts=$(echo ${NO_PROXY} | sed 's/,/|/g')
+-Dhttp.proxyHost=${PROXY_HOST} -Dhttp.proxyPort=${PROXY_PORT} -Dhttps.proxyHost=${PROXY_HOST} -Dhttps.proxyPort=${PROXY_PORT} -Dhttp.nonProxyHosts=$(echo ${NO_PROXY} | sed 's/,/|/g')
 {{- end }}
 
 {{/*

--- a/charts/bioentities-collection/templates/secret.yaml
+++ b/charts/bioentities-collection/templates/secret.yaml
@@ -25,13 +25,13 @@ stringData:
     */}}
     solr.hosts = http://{{ include "app.solrHost" . }}/solr
     solr.user = {{ .Values.solr.user }}
-    solr.pass = {{ .Values.solr.password }}
+    solr.pass = {{ .Values.solr.password | default "" | quote }}
     solr.collection = {{ .Values.solr.bioentities.collection }}
     solr.numShards = {{ .Values.solr.numShards | default "4" }}
     solr.timeout = {{ .Values.solr.timeout | default "30000" }}
   # Individual credentials for environment variables
   SOLR_USER: {{ .Values.solr.user }}
-  SOLR_PASS: {{ .Values.solr.password }}
+  SOLR_PASS: {{ .Values.solr.password | default "" | quote }}
   {{- end }}
 
 {{- /* Optional docker-registry Secret for image pulls */}}

--- a/charts/bioentities-collection/templates/solrcloud-bioentities-jsonl.yaml
+++ b/charts/bioentities-collection/templates/solrcloud-bioentities-jsonl.yaml
@@ -79,12 +79,7 @@ spec:
               done
 
               cd /atlas-web-bulk
-              ./gradlew --no-watch-fs \
-              {{ include "app.gradleCliArgs" . | indent 14 }} \
-              -PdataFilesLocation={{ include "app.dataDir" . }} \
-              -PexperimentDesignLocation={{ include "app.bioentityPropertiesDir" . }} \
-              -PexperimentFilesLocation={{ include "app.experimentsDir" . }} \
-              :cli:bootRun --args="bioentities-json --output={{ include "app.bioentitiesJsonlDir" . }}"
+              ./gradlew --no-watch-fs {{ include "app.gradleCliArgs" . | indent 14 }} -PdataFilesLocation={{ include "app.dataDir" . }} -PexperimentDesignLocation={{ include "app.bioentityPropertiesDir" . }} -PexperimentFilesLocation={{ include "app.experimentsDir" . }} :cli:bootRun --args="bioentities-json --output={{ include "app.bioentitiesJsonlDir" . }}"
 
           volumeMounts:
             # this is the volume where the bioentity_properties files are stored

--- a/charts/bioentities-collection/values.yaml
+++ b/charts/bioentities-collection/values.yaml
@@ -115,3 +115,5 @@ solr:
 
 jdbc:
   createSecret: true
+
+experiment_ids: ""

--- a/charts/scxa/.helmignore
+++ b/charts/scxa/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/scxa/Chart.lock
+++ b/charts/scxa/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: bioentities-collection
+  repository: file://../bioentities-collection
+  version: 0.1.0
+digest: sha256:b5435bc4395ae5abc71925903cef813a47ac91eac26611dae63f48702dce3484
+generated: "2025-10-22T14:51:23.671506+01:00"

--- a/charts/scxa/Chart.yaml
+++ b/charts/scxa/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+icon: "https://www.ebi.ac.uk/gxa/resources/images/expression-atlas.png"
+name: scxa
+description: A Helm chart for Kubernetes for the deployment of Single Cell Expression Atlas
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "17.2.0"

--- a/charts/scxa/Chart.yaml
+++ b/charts/scxa/Chart.yaml
@@ -23,3 +23,8 @@ version: 0.1.0
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "17.2.0"
+
+dependencies:
+  - name: bioentities-collection
+    version: "0.1.0"
+    repository: "file://../bioentities-collection"

--- a/charts/scxa/templates/_helpers.tpl
+++ b/charts/scxa/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "app.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "app.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "app.labels" -}}
+helm.sh/chart: {{ include "app.chart" . }}
+{{ include "app.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "app.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "app.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/scxa/templates/_helpers.tpl
+++ b/charts/scxa/templates/_helpers.tpl
@@ -80,6 +80,13 @@ Root directory for data mounts
 NFS volume mounts, used in deployments and jobs
 */}}
 
+{{- define "app.scxaCodonVolume" -}}
+- name: {{ include "app.name" . }}-codon-volume
+  nfs:
+    server: {{ .Values.nfs.server }}
+    path: /ifs/public/ro/scxa_codon/atlas_sc_experiments
+{{- end }}
+
 {{- define "app.servicesVolume" -}}
 - name: services-volume
   nfs:

--- a/charts/scxa/templates/_helpers.tpl
+++ b/charts/scxa/templates/_helpers.tpl
@@ -60,3 +60,93 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Root directory for data mounts
+*/}}
+{{- define "app.dataDir" -}}
+/atlas-data
+{{- end }}
+
+{{- define "app.experimentsDir" -}}
+{{ include "app.dataDir" . }}/exp
+{{- end }}
+
+{{- define "app.servicesDir" -}}
+{{ include "app.dataDir" . }}/services
+{{- end }}
+
+{{/*
+NFS volume mounts, used in deployments and jobs
+*/}}
+
+{{- define "app.servicesVolume" -}}
+- name: services-volume
+  nfs:
+    server: {{ .Values.nfs.server }}
+    path: /ifs/public/services
+{{- end }}
+
+{{/*
+Secrets volume mount
+*/}}
+{{- define "app.secretsVolume" -}}
+- name: {{ include "app.name" . }}-secrets
+  secret:
+    secretName: {{ include "app.fullname" . }}-secrets
+{{- end }}
+
+{{/*
+Proxy environment variables, used in containers
+*/}}
+{{- define "app.proxyEnv" -}}
+- name: HTTP_PROXY
+  valueFrom:
+    configMapKeyRef:
+      name: ebi-proxy
+      key: HTTP_PROXY
+- name: HTTPS_PROXY
+  valueFrom:
+    configMapKeyRef:
+      name: ebi-proxy
+      key: HTTPS_PROXY
+- name: http_proxy
+  valueFrom:
+    configMapKeyRef:
+      name: ebi-proxy
+      key: HTTP_PROXY
+- name: https_proxy
+  valueFrom:
+    configMapKeyRef:
+      name: ebi-proxy
+      key: HTTPS_PROXY
+- name: NO_PROXY
+  valueFrom:
+    configMapKeyRef:
+      name: ebi-proxy
+      key: NO_PROXY
+- name: PROXY_HOST
+  valueFrom:
+    configMapKeyRef:
+      name: ebi-proxy
+      key: PROXY_HOST
+- name: PROXY_PORT
+  valueFrom:
+    configMapKeyRef:
+      name: ebi-proxy
+      key: PROXY_PORT
+{{- end }}
+
+{{/*
+Solr Zookeeper hosts URL
+*/}}
+{{- define "app.solrZkHosts" -}}
+{{ .Values.solr.namespace }}-zookeeper-client.{{ .Values.solr.namespace }}.svc.cluster.local:2181
+{{- end }}
+
+{{/*
+Solr hosts URL
+*/}}
+{{- define "app.solrHost" -}}
+{{ .Values.solr.namespace }}-common.{{ .Values.solr.namespace }}.svc.cluster.local
+{{- end }}

--- a/charts/scxa/templates/configmap.yaml
+++ b/charts/scxa/templates/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "app.fullname" . }}-config
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+data:
+{{/*  experiment_ids: {{ .Values.experiment_ids | quote }}*/}}
+
+  species: |
+    danio_rerio homo_sapiens equus_caballus drosophila_melanogaster
+    caenorhabditis_elegans mus_musculus oryza_indica anas_platyrhynchos
+    oryza_sativa brachypodium_distachyon schistosoma_mansoni zea_mays
+    saccharomyces_cerevisiae schizosaccharomyces_pombe
+
+  # Solr configuration
+  SOLR_HOST: "{{ include "app.solrHost" . }}"
+  SOLR_ZK_HOSTS: "{{ include "app.solrZkHosts" . }}"
+  SOLR_SCXA_ANALYTICS_COLLECTION: "{{ .Values.solr.scxaAnalytics.collection  }}"
+  SOLR_NUM_SHARDS: "{{ .Values.solr.numShards | default "4" }}"
+  SOLR_TIMEOUT: "{{ .Values.solr.timeout | default "30000" }}"
+

--- a/charts/scxa/templates/configmap.yaml
+++ b/charts/scxa/templates/configmap.yaml
@@ -5,13 +5,14 @@ metadata:
   labels:
     {{- include "app.labels" . | nindent 4 }}
 data:
-{{/*  experiment_ids: {{ .Values.experiment_ids | quote }}*/}}
-
   species: |
     danio_rerio homo_sapiens equus_caballus drosophila_melanogaster
     caenorhabditis_elegans mus_musculus oryza_indica anas_platyrhynchos
     oryza_sativa brachypodium_distachyon schistosoma_mansoni zea_mays
     saccharomyces_cerevisiae schizosaccharomyces_pombe
+
+  experiment_ids: {{ .Values.experiment_ids | quote }}
+
 
   # Solr configuration
   SOLR_HOST: "{{ include "app.solrHost" . }}"

--- a/charts/scxa/templates/deployment.yaml
+++ b/charts/scxa/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "app.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "app.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/scxa/templates/ebi-proxy.yaml
+++ b/charts/scxa/templates/ebi-proxy.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ebi-proxy
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+data:
+  HTTP_PROXY: "http://hx-wwwcache.ebi.ac.uk:3128"
+  HTTPS_PROXY: "http://hx-wwwcache.ebi.ac.uk:3128"
+  PROXY_HOST: "hx-wwwcache.ebi.ac.uk"
+  PROXY_PORT: "3128"
+  NO_PROXY: "localhost,127.0.0.1,.cluster.local,.svc,.svc.cluster.local"

--- a/charts/scxa/templates/secret.yaml
+++ b/charts/scxa/templates/secret.yaml
@@ -39,3 +39,12 @@ type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ required "registrySecret.dockerconfigjson must be set when registrySecret.create=true" .Values.registrySecret.dockerconfigjson | b64enc | quote }}
 {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "app.fullname" . }}-biosolr-private-key
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+data:
+  solrcloud.pem: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUJWUUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQVQ4d2dnRTdBZ0VBQWtFQXBreVlac3RFZ2xkc1kxVTQKNXlqZWxpQisxRGEzRTY3RW94RmlUYnhwWDE5RVMxWHZ6cFQzQmg2VXpPRjJyclBJZTljWmVLVjNTVWU4NmkrawpoV0J6andJREFRQUJBa0JDRTMwYW12bUZzS2JvY1J4Qy9RSTBOSVV3WE8weGJPZkV3MHVFQjdEMnE0ZVNDWVNPCmd0NTR0OGw4TENZYnhvanE4RnZkbEpidnppTHoyQStxakF5QkFpRUEyUW1zVFhuRUhqbUFuOER1bGFPWXNsenIKS1RES1ZvR1FKUVJUenRVY2Fla0NJUURFSnlYQlBXSmdNajltZjBVemk4NnNQdXMrRllSQmlJTkQ0ZEZyTEZZTwp0d0loQU1NM2xDZkwwcjlzOFdqQVhObHo0VER0cXdmTnZ2RzRjRE1iaFZhUkVaR2hBaUE5cWp6eFNoWHlQZm0yCmhFNUNEVEswN2JiUXRyejBTVEZURnR2YVFIN3hjd0loQU1LNUhUKzZRelVmRTFqWEJTcnloTmtLM1ducVRzKysKODljaVRGdUpjU0taCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K

--- a/charts/scxa/templates/secret.yaml
+++ b/charts/scxa/templates/secret.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "app.fullname" . }}-secrets
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: delete
+type: Opaque
+stringData:
+  {{- if and (not (empty .Values.solr)) .Values.solr.createSecret }}
+  solr.properties: |
+    zk.hosts = {{ include "app.solrZkHosts" . }}
+    {{- /* 
+      for the Java app the solr.hosts property is actually the solr URL 
+      (including http:// and port)
+    */}}
+    solr.hosts = http://{{ include "app.solrHost" . }}/solr
+    solr.user = {{ .Values.solr.user }}
+    solr.pass = {{ .Values.solr.password }}
+    solr.collection = {{ .Values.solr.scxaAnalytics.collection }}
+    solr.numShards = {{ .Values.solr.numShards | default "4" }}
+    solr.timeout = {{ .Values.solr.timeout | default "30000" }}
+  # Individual credentials for environment variables
+  SOLR_USER: {{ .Values.solr.user }}
+  SOLR_PASS: {{ .Values.solr.password }}
+  {{- end }}
+
+{{- /* Optional docker-registry Secret for image pulls */}}
+{{- if and .Values.registrySecret .Values.registrySecret.create | default false }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ default (printf "%s-registry" (include "app.fullname" .)) .Values.registrySecret.name }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ required "registrySecret.dockerconfigjson must be set when registrySecret.create=true" .Values.registrySecret.dockerconfigjson | b64enc | quote }}
+{{- end }}

--- a/charts/scxa/templates/secret.yaml
+++ b/charts/scxa/templates/secret.yaml
@@ -8,6 +8,14 @@ metadata:
     helm.sh/resource-policy: delete
 type: Opaque
 stringData:
+  {{- if and (not (empty .Values.jdbc)) .Values.jdbc.createSecret }}
+  jdbc.properties: |
+    jdbc.url = {{ .Values.jdbc.url }}
+    jdbc.username = atlasprd3
+    jdbc.password = {{ .Values.jdbc.password }}
+    jdbc.pool = gxa
+    {{- end }}
+
   {{- if and (not (empty .Values.solr)) .Values.solr.createSecret }}
   solr.properties: |
     zk.hosts = {{ include "app.solrZkHosts" . }}

--- a/charts/scxa/templates/service.yaml
+++ b/charts/scxa/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "app.selectorLabels" . | nindent 4 }}

--- a/charts/scxa/templates/serviceaccount.yaml
+++ b/charts/scxa/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "app.serviceAccountName" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/scxa/templates/serviceaccount.yaml
+++ b/charts/scxa/templates/serviceaccount.yaml
@@ -9,4 +9,16 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- range . }}
+  - name: {{ . }}
+  {{- end }}
 {{- end }}
+{{- end }}
+{{- if and .Values.registrySecret .Values.registrySecret.create }}
+imagePullSecrets:
+  - name: {{ default (printf "%s-registry" (include "app.fullname" .)) .Values.registrySecret.name }}
+{{- end }}
+---
+{{ include "app.jobsRbac" . }}

--- a/charts/scxa/templates/solrcloud-scxa-analytics-populator.yaml
+++ b/charts/scxa/templates/solrcloud-scxa-analytics-populator.yaml
@@ -20,11 +20,10 @@ spec:
               - key: solrcloud.pem
                 path: scxa-solrcloud.pem
         {{- include "app.secretsVolume" . | nindent 8 }}
+        {{- include "app.scxaCodonVolume" . | nindent 8 }}
         - name: solr-config
           configMap:
             name: {{ include "app.fullname" . }}-config
-        - name: {{ include "app.name" . }}-data-vol
-          emptyDir: { }
       containers:
         - name: scxa-analytics-populator
           image: openjdk:11
@@ -38,7 +37,12 @@ spec:
             - name: SIGNING_PRIVATE_KEY
               value: "/keys/scxa-solrcloud.pem"
             - name: SCXA_ONTOLOGY
-              value: "/var/solr/data/userfiles/scatlas.owl"
+              value: "file://var/solr/data/userfiles/scatlas.owl"
+            - name: EXP_IDS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "app.fullname" . }}-config
+                  key: experiment_ids
             {{- include "app.proxyEnv" . | nindent 12 }}
             # From Secret (sensitive credentials)
             - name: SOLR_USER
@@ -100,13 +104,7 @@ spec:
               # install dependencies, TODO: should build an use a custom image with dependencies installed
               apt-get update && apt-get install -y jq
 
-              mkdir {{ include "app.experimentsDir" . }}/magetab
-              ln -s {{ include "app.servicesDir" . }}/fg/atlas/{{ .Values.nfs.snapshotComponent }}/* \
-                    {{ include "app.experimentsDir" . }}/magetab
-
-              mkdir /work
-
-              cd /work
+              mkdir /work && cd /work
 
               git clone --recurse-submodules --depth 1 --single-branch https://github.com/ebi-gene-expression-group/index-scxa.git
 
@@ -116,18 +114,20 @@ spec:
               ./create-scxa-analytics-collection.sh
               ./create-scxa-analytics-schema.sh
               ./create-scxa-analytics-suggesters.sh
+
               for EXP_ID in ${EXP_IDS}
               do
                 CONDENSED_SDRF_TSV=/atlas-data/exp/magetab/$${EXP_ID}/$${EXP_ID}.condensed-sdrf.tsv \
                 ./load-scxa-analytics.sh
               done
+
               ./build-scxa-analytics-suggestions.sh
           volumeMounts:
+            - name: {{ include "app.name" . }}-codon-volume
+              mountPath: {{ include "app.dataDir" . }}/exp/magetab
             - name: scxa-biosolr-private-key-vol
               mountPath: /keys
               readOnly: true
-            - name: {{ include "app.name" . }}-data-vol
-              mountPath: "{{ include "app.experimentsDir" . }}"
             - name: solr-config
               mountPath: /etc/solr
               readOnly: true

--- a/charts/scxa/templates/solrcloud-scxa-analytics-populator.yaml
+++ b/charts/scxa/templates/solrcloud-scxa-analytics-populator.yaml
@@ -139,6 +139,6 @@ spec:
           - "wait"
           - "--for=condition=complete"
           - "--timeout=1h"
-          - "job/bioentities-jsonl"
+          - "job/bioentities-populator"
       restartPolicy: Never
 {{- end }}

--- a/charts/scxa/templates/solrcloud-scxa-analytics-populator.yaml
+++ b/charts/scxa/templates/solrcloud-scxa-analytics-populator.yaml
@@ -13,6 +13,12 @@ spec:
     spec:
       serviceAccountName: {{ include "app.serviceAccountName" . }}
       volumes:
+        - name: scxa-biosolr-private-key-vol
+          secret:
+            secretName: scxa-biosolr-private-key
+            items:
+              - key: solrcloud.pem
+                path: scxa-solrcloud.pem
         {{- include "app.secretsVolume" . | nindent 8 }}
         - name: solr-config
           configMap:
@@ -30,7 +36,9 @@ spec:
             - name: BIOSOLR_JAR_PATH
               value: "/work/index-scxa/lib/solr-ontology-update-processor-2.0.0.jar"
             - name: SIGNING_PRIVATE_KEY
-              value: "/run/secrets/solrcloud.pem"
+              value: "/keys/scxa-solrcloud.pem"
+            - name: SCXA_ONTOLOGY
+              value: "/var/solr/data/userfiles/scatlas.owl"
             {{- include "app.proxyEnv" . | nindent 12 }}
             # From Secret (sensitive credentials)
             - name: SOLR_USER
@@ -76,7 +84,7 @@ spec:
                   key: SOLR_TIMEOUT
             # Job-specific environment variables
             - name: SCHEMA_VERSION
-              value: "1"
+              value: "8"
           resources:
             requests:
               cpu: "1"
@@ -88,6 +96,9 @@ spec:
           args:
             - |
               set -ev
+
+              # install dependencies, TODO: should build an use a custom image with dependencies installed
+              apt-get update && apt-get install -y jq
 
               mkdir {{ include "app.experimentsDir" . }}/magetab
               ln -s {{ include "app.servicesDir" . }}/fg/atlas/{{ .Values.nfs.snapshotComponent }}/* \
@@ -112,19 +123,22 @@ spec:
               done
               ./build-scxa-analytics-suggestions.sh
           volumeMounts:
+            - name: scxa-biosolr-private-key-vol
+              mountPath: /keys
+              readOnly: true
             - name: {{ include "app.name" . }}-data-vol
               mountPath: "{{ include "app.experimentsDir" . }}"
             - name: solr-config
               mountPath: /etc/solr
               readOnly: true
-{{/*      initContainers:*/}}
-{{/*        - name: wait-for-previous-job*/}}
-{{/*          image: dtzar/helm-kubectl:3.16.2*/}}
-{{/*          command: ["kubectl"]*/}}
-{{/*          args:*/}}
-{{/*          - "wait"*/}}
-{{/*          - "--for=condition=complete"*/}}
-{{/*          - "--timeout=1h"*/}}
-{{/*          - "job/bioentities-jsonl"*/}}
+      initContainers:
+        - name: wait-for-previous-job
+          image: dtzar/helm-kubectl:3.16.2
+          command: ["kubectl"]
+          args:
+          - "wait"
+          - "--for=condition=complete"
+          - "--timeout=1h"
+          - "job/bioentities-jsonl"
       restartPolicy: Never
 {{- end }}

--- a/charts/scxa/templates/solrcloud-scxa-analytics-populator.yaml
+++ b/charts/scxa/templates/solrcloud-scxa-analytics-populator.yaml
@@ -1,0 +1,130 @@
+{{- if and .Values.solr .Values.solr.scxaAnalytics.populator .Values.solr.scxaAnalytics.populator.enabled | default false -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: scxa-analytics-populator
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "app.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "app.serviceAccountName" . }}
+      volumes:
+        {{- include "app.secretsVolume" . | nindent 8 }}
+        - name: solr-config
+          configMap:
+            name: {{ include "app.fullname" . }}-config
+        - name: {{ include "app.name" . }}-data-vol
+          emptyDir: { }
+      containers:
+        - name: scxa-analytics-populator
+          image: openjdk:11
+          env:
+            - name: JAVA_TOOLS_OPTIONS
+              value: "-Dfile.encoding=UTF-8 -Dsolr.httpclient.builder.factory=org.apache.solr.client.solrj.impl.PreemptiveBasicAuthClientBuilderFactory -Dbasicauth=\"${SOLR_USER}:${SOLR_PASS}\""
+            - name: BIOSOLR_VERSION
+              value: "2.0.0"
+            - name: BIOSOLR_JAR_PATH
+              value: "/work/index-scxa/lib/solr-ontology-update-processor-2.0.0.jar"
+            - name: SIGNING_PRIVATE_KEY
+              value: "/run/secrets/solrcloud.pem"
+            {{- include "app.proxyEnv" . | nindent 12 }}
+            # From Secret (sensitive credentials)
+            - name: SOLR_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "app.fullname" . }}-secrets
+                  key: SOLR_USER
+            - name: SOLR_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "app.fullname" . }}-secrets
+                  key: SOLR_PASS
+            # From ConfigMap (non-sensitive configuration)
+            - name: SOLR_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "app.fullname" . }}-config
+                  key: SOLR_HOST
+            - name: SOLR_HOSTS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "app.fullname" . }}-config
+                  key: SOLR_HOST
+            - name: SOLR_ZK_HOSTS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "app.fullname" . }}-config
+                  key: SOLR_ZK_HOSTS
+            - name: SOLR_COLLECTION
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "app.fullname" . }}-config
+                  key: SOLR_SCXA_ANALYTICS_COLLECTION
+            - name: SOLR_NUM_SHARDS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "app.fullname" . }}-config
+                  key: SOLR_NUM_SHARDS
+            - name: SOLR_TIMEOUT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "app.fullname" . }}-config
+                  key: SOLR_TIMEOUT
+            # Job-specific environment variables
+            - name: SCHEMA_VERSION
+              value: "1"
+          resources:
+            requests:
+              cpu: "1"
+              memory: 500Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -ev
+
+              mkdir {{ include "app.experimentsDir" . }}/magetab
+              ln -s {{ include "app.servicesDir" . }}/fg/atlas/{{ .Values.nfs.snapshotComponent }}/* \
+                    {{ include "app.experimentsDir" . }}/magetab
+
+              mkdir /work
+
+              cd /work
+
+              git clone --recurse-submodules --depth 1 --single-branch https://github.com/ebi-gene-expression-group/index-scxa.git
+
+              cd index-scxa/bin
+              export PATH=.:$${PATH}
+              ./upload-biosolr-lib.sh
+              ./create-scxa-analytics-collection.sh
+              ./create-scxa-analytics-schema.sh
+              ./create-scxa-analytics-suggesters.sh
+              for EXP_ID in ${EXP_IDS}
+              do
+                CONDENSED_SDRF_TSV=/atlas-data/exp/magetab/$${EXP_ID}/$${EXP_ID}.condensed-sdrf.tsv \
+                ./load-scxa-analytics.sh
+              done
+              ./build-scxa-analytics-suggestions.sh
+          volumeMounts:
+            - name: {{ include "app.name" . }}-data-vol
+              mountPath: "{{ include "app.experimentsDir" . }}"
+            - name: solr-config
+              mountPath: /etc/solr
+              readOnly: true
+{{/*      initContainers:*/}}
+{{/*        - name: wait-for-previous-job*/}}
+{{/*          image: dtzar/helm-kubectl:3.16.2*/}}
+{{/*          command: ["kubectl"]*/}}
+{{/*          args:*/}}
+{{/*          - "wait"*/}}
+{{/*          - "--for=condition=complete"*/}}
+{{/*          - "--timeout=1h"*/}}
+{{/*          - "job/bioentities-jsonl"*/}}
+      restartPolicy: Never
+{{- end }}

--- a/charts/scxa/values-test.yaml
+++ b/charts/scxa/values-test.yaml
@@ -1,0 +1,16 @@
+# values for gxa test env
+environment: test
+
+loggingLevel: DEBUG
+
+jdbc:
+  url: "jdbc:postgresql://pgsql-dlvm-062.ebi.ac.uk:5432/gxpscxatst"
+  createSecret: true
+
+solr:
+  namespace: scxa-dev-solrcloud
+  user: admin
+  createSecret: true
+
+nfs:
+  snapshotComponent: experiments_test

--- a/charts/scxa/values-test.yaml
+++ b/charts/scxa/values-test.yaml
@@ -23,8 +23,15 @@ bioentities-collection:
     url: "jdbc:postgresql://pgsql-dlvm-062.ebi.ac.uk:5432/gxpscxatst"
     createSecret: true
   solr:
+    namespace: "scxa-dev-solrcloud"
+    user: admin
+    numShards: "4"
+    timeout: "30000"
+    createSecret: true
     bioentities:
+      collection: bioentities
       jsonl:
         enabled: true
       populator:
         enabled: true
+        gitBranch: feature/amnon-GXA-333-populate-solr-on-k8s

--- a/charts/scxa/values-test.yaml
+++ b/charts/scxa/values-test.yaml
@@ -14,3 +14,5 @@ solr:
 
 nfs:
   snapshotComponent: experiments_test
+
+experiment_ids: "E-CURD-4 E-EHCA-2 E-GEOD-71585 E-GEOD-81547 E-GEOD-99058 E-MTAB-5061 E-ENAD-53"

--- a/charts/scxa/values-test.yaml
+++ b/charts/scxa/values-test.yaml
@@ -16,3 +16,15 @@ nfs:
   snapshotComponent: experiments_test
 
 experiment_ids: "E-CURD-4 E-EHCA-2 E-GEOD-71585 E-GEOD-81547 E-GEOD-99058 E-MTAB-5061 E-ENAD-53"
+
+bioentities-collection:
+  enabled: true
+  jdbc:
+    url: "jdbc:postgresql://pgsql-dlvm-062.ebi.ac.uk:5432/gxpscxatst"
+    createSecret: true
+  solr:
+    bioentities:
+      jsonl:
+        enabled: true
+      populator:
+        enabled: true

--- a/charts/scxa/values.yaml
+++ b/charts/scxa/values.yaml
@@ -106,14 +106,8 @@ solr:
       enabled: true
     collection: scxa-analytics-v8
 
+jdbc:
+  createSecret: true
+
 nfs:
   server: hh-isi-srv-vlan1496.ebi.ac.uk
-
-bioentities-collection:
-  enabled: true
-  solr:
-    bioentities:
-      jsonl:
-        enabled: true
-      populator:
-        enabled: true

--- a/charts/scxa/values.yaml
+++ b/charts/scxa/values.yaml
@@ -23,6 +23,20 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+registrySecret:
+  create: false
+  # If empty and create=true, defaults to "{{ include \"app.fullname\" . }}-registry"
+  # name: ""
+  # Provide the full Docker config JSON content for the key ".dockerconfigjson".
+  # TIP: Populate this via CI secrets; do not commit real credentials to Git.
+  # Example content (abbreviated):
+  # {
+  #   "auths": {
+  #     "ghcr.io": {"auth": "<base64(user:token)>"}
+  #   }
+  # }
+  dockerconfigjson: ""
+
 podAnnotations: {}
 
 podSecurityContext: {}
@@ -80,3 +94,17 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+solr:
+  namespace: scxa-dev-solrcloud
+  user: admin
+  numShards: "4"
+  timeout: "30000"
+  createSecret: true
+  scxaAnalytics:
+    populator:
+      enabled: true
+    collection: scxa-analytics
+
+nfs:
+  server: hh-isi-srv-vlan1496.ebi.ac.uk

--- a/charts/scxa/values.yaml
+++ b/charts/scxa/values.yaml
@@ -1,0 +1,82 @@
+# Default values for scxa.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: tomcat
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "8-jdk11"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: NodePort
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/scxa/values.yaml
+++ b/charts/scxa/values.yaml
@@ -104,7 +104,7 @@ solr:
   scxaAnalytics:
     populator:
       enabled: true
-    collection: scxa-analytics
+    collection: scxa-analytics-v8
 
 nfs:
   server: hh-isi-srv-vlan1496.ebi.ac.uk

--- a/charts/scxa/values.yaml
+++ b/charts/scxa/values.yaml
@@ -108,3 +108,12 @@ solr:
 
 nfs:
   server: hh-isi-srv-vlan1496.ebi.ac.uk
+
+bioentities-collection:
+  enabled: true
+  solr:
+    bioentities:
+      jsonl:
+        enabled: true
+      populator:
+        enabled: true


### PR DESCRIPTION
This task contains the following:
- Creates a Helm chart for SCXA.
- Move data generation and population for bioentities collection to its separate Helm chart and use that as a dependency for SCXA chart.
- Adds a job to create a populate scxa-analytics collection. It uses config maps, secrets, a service account and value files.

I tested it and it successfully populated the bioentities and scxa-analytics collection using the test data on our k8s env.